### PR TITLE
Support specifying axis minima/maxima for rectangular grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Release v0.3.2
+
+## New functionality 
+- Support specifying axis minima/maxima for rectangular grid.
+
+## Improvements
+- Inputs to `customembed` are now validated.
+
+
 # Release v0.3.1
 
 ## New functionality 

--- a/src/discretization/minima_edgelengths.jl
+++ b/src/discretization/minima_edgelengths.jl
@@ -1,7 +1,59 @@
+import DelayEmbeddings: Dataset, minima, maxima
+import StaticArrays: SVector, MVector
+
 export 
 get_minima_and_edgelengths, 
 get_edgelengths, 
-get_minima
+get_minima,
+get_minmaxes
+
+
+"""
+    get_minima(pts) -> Vector{Float}
+
+Return the minima along each axis of the dataset `pts`.
+"""
+function get_minima end
+
+"""
+    get_maxima(pts) -> Vector{Float}
+
+Return the maxima along each axis of the dataset `pts`.
+"""
+function get_minima end
+
+function get_minima(pts::Dataset)
+    minima(pts)
+end
+
+function get_minima(pts::Vector{T}) where {T <: Union{SVector, MVector, Vector}}
+    minima(Dataset(pts))
+end
+
+function get_maxima(pts::Dataset)
+    maxima(pts)
+end
+
+function get_maxima(pts::Vector{T}) where {T <: Union{SVector, MVector, Vector}}
+    maxima(Dataset(pts))
+end
+
+"""
+    get_minmaxes(pts) -> Tuple{Vector{Float}, Vector{Float}}
+
+Return a vector of tuples containing axis-wise (minimum, maximum) values.
+"""
+function get_minmaxes end
+
+function get_minmaxes(pts::Dataset)
+    mini, maxi = minima(pts), maxima(pts)
+    minmaxes = [(mini[i], maxi[i]) for i = 1:length(mini)]
+end
+
+function get_minmaxes(pts::Vector{T}) where {T <: Union{SVector, MVector, Vector}}
+    get_minmaxes(Dataset(pts))
+end
+
 
 """
     get_minima_and_edgelengths(points, ϵ) -> (Vector{Float}, Vector{Float})
@@ -43,10 +95,10 @@ function get_minima_and_edgelengths(points, ϵ)
     elseif ϵ isa Tuple{Vector{Tuple{Float64, Float64}}, Int}
         # We have predefined axis minima and axis maxima.
         n_bins = ϵ[2]
-        stepsizes = zeros(Float64, dim)
-        edgelengths = zeros(Float64, dim)
+        stepsizes = zeros(Float64, D)
+        edgelengths = zeros(Float64, D)
 
-        for i = 1:dim 
+        for i = 1:D
             edgelengths[i] = (maximum(ϵ[1][i]) - minimum(ϵ[1][i]))/n_bins
             axisminima[i] = minimum(ϵ[1][i])
         end
@@ -55,9 +107,18 @@ function get_minima_and_edgelengths(points, ϵ)
     axisminima, edgelengths
 end
 
-get_minima(points, ϵ) = get_minima_and_edgelengths(points, ϵ)[1]
-get_edgelengths(points, ϵ) = get_minima_and_edgelengths(points, ϵ)[2]
-
 get_minima_and_edgelengths(points, ϵ::RectangularBinning) = get_minima_and_edgelengths(points, ϵ.ϵ)
-get_minima(points, ϵ::RectangularBinning) = get_minima(points, ϵ.ϵ)
-get_edgelengths(points, ϵ::RectangularBinning) = get_minima(points, ϵ.ϵ)
+
+
+"""
+    get_edgelengths(pts, ϵ) -> Vector{Float}
+
+Return the box edge length along each axis resulting from 
+discretizing `pts` on a rectangular grid specified by the 
+binning scheme `ϵ`.
+"""
+function get_edgelengths end
+
+get_edgelengths(points, ϵ) = get_minima_and_edgelengths(points, ϵ)[2]
+get_edgelengths(points, ϵ::RectangularBinning) = get_edgelengths(points, ϵ.ϵ)
+

--- a/test/test_bin_encode.jl
+++ b/test/test_bin_encode.jl
@@ -1,9 +1,30 @@
+pts = [rand(3) for i = 1:100]
+spts = [SVector{3, Float64}(pt) for pt in pts]
+mpts = [MVector{3, Float64}(pt) for pt in pts]
+
+D = Dataset(pts)
+@test get_minmaxes(pts) isa Vector{Tuple{Float64, Float64}}
+@test get_minmaxes(spts) isa Vector{Tuple{Float64, Float64}}
+@test get_minmaxes(mpts) isa Vector{Tuple{Float64, Float64}}
+@test get_minmaxes(D) isa Vector{Tuple{Float64, Float64}}
+
+@test get_minima(pts) isa Vector{Float64}
+@test get_minima(D) isa Vector{Float64}
+@test get_minima(spts) isa Vector{Float64}
+@test get_minima(mpts) isa Vector{Float64}
+
+@test get_maxima(pts) isa Vector{Float64}
+@test get_maxima(D) isa Vector{Float64}
+@test get_maxima(spts) isa Vector{Float64}
+@test get_maxima(mpts) isa Vector{Float64}
+
 pts = [rand(5) for i = 1:1000];
 spts = [SVector{5, Float64}(pt) for pt in pts]
 mpts = [MVector{5, Float64}(pt) for pt in pts]
 D = Dataset(pts);
 
-ϵs = [5, 0.5, [0.3 for i = 1:5], [10 for i = 1:5]]
+ϵs = [5, 0.5, [0.3 for i = 1:5], [10 for i = 1:5], (get_minmaxes(pts), 10)]
+
 
 refpoint = [0, 0, 0]
 steps = [0.2, 0.2, 0.3]
@@ -11,13 +32,12 @@ steps = [0.2, 0.2, 0.3]
 @test encode(SVector{3, Float64}(rand(3)), refpoint, steps) isa Vector{Int}
 @test encode(MVector{3, Float64}(rand(3)), refpoint, steps) isa Vector{Int}
 
+@test encode([rand(3) for i = 1:20], [0, 0, 0], [0.1, 0.1, 0.1]) isa Vector{Vector{Int}}
+@test encode([SVector{3, Float64}(rand(3)) for i = 1:20], [0, 0, 0], [0.1, 0.1, 0.1]) isa Vector{Vector{Int}}
+@test encode([MVector{3, Float64}(rand(3)) for i = 1:20], [0, 0, 0], [0.1, 0.1, 0.1]) isa Vector{Vector{Int}}
+
 # Infer that we want a rectangular binning.
 for ϵ in ϵs
-    @test get_minima(pts, ϵ) isa Vector{Float64}
-    @test get_minima(D, ϵ) isa Vector{Float64}
-    @test get_minima(spts, ϵ) isa Vector{Float64}
-    @test get_minima(mpts, ϵ) isa Vector{Float64}
-
     @test get_edgelengths(pts, ϵ) isa Vector{Float64}
     @test get_edgelengths(D, ϵ) isa Vector{Float64}
     @test get_edgelengths(spts, ϵ) isa Vector{Float64}
@@ -33,11 +53,6 @@ end
 for ϵ in ϵs
     ϵ = RectangularBinning(ϵ)
     
-    @test get_minima(pts, ϵ) isa Vector{Float64}
-    @test get_minima(D, ϵ) isa Vector{Float64}
-    @test get_minima(spts, ϵ) isa Vector{Float64}
-    @test get_minima(mpts, ϵ) isa Vector{Float64}
-
     @test get_edgelengths(pts, ϵ) isa Vector{Float64}
     @test get_edgelengths(D, ϵ) isa Vector{Float64}
     @test get_edgelengths(spts, ϵ) isa Vector{Float64}


### PR DESCRIPTION
# Release v0.3.2
- Support specifying axis minima/maxima for rectangular grid.
- Validate inputs to `customembed`.