### PR TITLE
Add abstract CausalityEstimator and CausalityEstimatorParams type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Release v0.5.0
+
+- Add abstract type `CausalityEstimator` that will be the supertype of all causality estimator types in the CausalityTools.jl ecosystem.
+- Add abstract type `CausalityEstimatorParams` that will be the supertype of all causality estimator parameter types in the CausalityTools.jl ecosystem.
+
+
 ## Release v0.4.2
 
 ### Improvements

--- a/src/CausalityToolsBase.jl
+++ b/src/CausalityToolsBase.jl
@@ -10,6 +10,10 @@ module CausalityToolsBase
 	
 	include("kerneldensity/kerneldensity.jl")
 	include("mutual_information/mutualinformation.jl") # must be loaded after kerneldensity
+	
+	# Defines supertypes for estimators and estimator parameter types
+	include("causalityestimator.jl")
+	include("causalityestimatorparams.jl")
 
 end # module
 

--- a/src/causalityestimator.jl
+++ b/src/causalityestimator.jl
@@ -1,0 +1,29 @@
+
+"""
+CausalityEstimator
+
+An abstract type that is the supertype of all causality estimators in the `CausalityTools` ecosystem.
+
+The naming convention for abstract subtypes is `SomeEstimator`. Examples of 
+abstract estimator type hierarchies could be:
+
+- `TransferEntropyEstimator <: CausalityEstimator`
+- `CrossMappingEstimator <: CausalityEstimator`
+
+
+Specific estimator types are named according to the algorithm. Examples of 
+complete type hierarchies for different estimators could be:
+
+- `VisitationFrequency <: TransferEntropyEstimator <: CausalityEstimator`.
+- `TransferOperatorGrid <: TransferEntropyEstimator <: CausalityEstimator`.
+- `SimpleCrossMap <: CrossMappingEstimator <: CausalityEstimator`.
+- `ConvergentCrossMap <: CrossMappingEstimator <: CausalityEstimator`.
+- `JointDistanceDistribution <: JointDistanceDistributionEstimator <: CausalityEstimator`.
+
+Each estimator type, also the abstract ones, have a corresponding parameter 
+type where `Params` is appending to the type name, for example 
+`VisitationFrequencyParams <: TransferEntropyEstimatorParams <: CausalityEstimatorParams`.
+"""
+abstract type CausalityEstimator end
+
+export CausalityEstimator

--- a/src/causalityestimatorparams.jl
+++ b/src/causalityestimatorparams.jl
@@ -1,0 +1,26 @@
+
+"""
+CausalityEstimatorParams
+
+An abstract type that is the supertype of all causality estimator parameter types 
+in the `CausalityTools` ecosystem. 
+
+The naming convention for abstract subtypes is `SomeEstimatorParams`. Examples of
+the type hierarchy of abstract estimator types could be:
+
+- `TransferEntropyEstimatorParams <: CausalityEstimatorParams`
+- `CrossMappingEstimatorParams <: CausalityEstimatorParams`
+
+
+Subtypes of those abstract types are named according to the specific algorithm. Examples
+of complete type hierachies for specific estimator parameter types could be:
+
+- `VisitationFrequencyParams <: TransferEntropyEstimatorParams <: CausalityEstimatorParams`.
+- `TransferOperatorGridParams <: TransferEntropyEstimatorParams <: CausalityEstimatorParams`.
+- `SimpleCrossMapParams <: CrossMappingEstimatorParams <: CausalityEstimatorParams`.
+- `ConvergentCrossMapParams <: CrossMappingEstimatorParams <: CausalityEstimatorParams`.
+- `JointDistanceDistributionParams <: JointDistanceDistributionEstimatorParams <: CausalityEstimatorParams`.
+"""
+abstract type CausalityEstimatorParams end
+
+export CausalityEstimatorParams


### PR DESCRIPTION
These types are the supertypes of all causality estimator and estimator parameter types through the CausalityTools.jl ecosystem