### PR TITLE
Add causality function

### DIFF
--- a/src/CausalityToolsBase.jl
+++ b/src/CausalityToolsBase.jl
@@ -14,6 +14,7 @@ module CausalityToolsBase
 	# Defines supertypes for estimators and estimator parameter types
 	include("causalityestimator.jl")
 	include("causalitytest.jl")
+	include("causality.jl")
 
 end # module
 

--- a/src/causality.jl
+++ b/src/causality.jl
@@ -1,0 +1,3 @@
+function causality end
+
+export causality


### PR DESCRIPTION
## Release v0.7.0

- Added `causality` function. The rest of the CausalityTools ecosystem extends this function
    with methods that specialize on different types of input. 